### PR TITLE
Added / endpoint to connectors for liveness checks etc

### DIFF
--- a/connectors/nodejs/file/bbk-webhook.js
+++ b/connectors/nodejs/file/bbk-webhook.js
@@ -70,7 +70,7 @@ module.exports = class BBKWebhook {
 
     // --- constructs a bbk webhook object
 
-    constructor() {
+    constructor(info) {
         this.app = express();
         this.router = express.Router();
 
@@ -93,6 +93,15 @@ module.exports = class BBKWebhook {
             } else {
                 BBKWebhook._http_server_error(res);
             }
+        });
+
+        this.info = info || {};
+
+        // --- handler / route
+
+        this.router.get('/', (req, res) => {
+            this.info.now = new Date().toISOString();
+            res.json(this.info);
         });
 
         // --- handler /entity route

--- a/connectors/nodejs/file/index.js
+++ b/connectors/nodejs/file/index.js
@@ -56,6 +56,7 @@ const CATALOG_HOST = process.env.CATALOG_HOST;
 const CONNECTOR_ID = process.env.CONNECTOR_ID;
 const AUTHORIZE_KEY = process.env.AUTHORIZE_KEY;
 const WEBHOOK_PORT = process.env.WEBHOOK_PORT;
+const ENTITY_TYPE = process.env.ENTITY_TYPE;
 const DATA_URL = process.env.DATA_URL;
 const DATA_FORMAT = process.env.DATA_FORMAT;
 
@@ -247,6 +248,6 @@ new MyCatalog().upsert();
   all your data into the bbk catalog instead.
 */
 
-new MyWebhook().listen(WEBHOOK_PORT, () => {
+new MyWebhook({ name: "BBK File Example Connector", entity: ENTITY_TYPE, connectorId: CONNECTOR_ID }).listen(WEBHOOK_PORT, () => {
     console.log(`Webhook is listening on port ${ WEBHOOK_PORT }`);
 });

--- a/connectors/nodejs/rdbms/bbk-webhook.js
+++ b/connectors/nodejs/rdbms/bbk-webhook.js
@@ -70,7 +70,7 @@ module.exports = class BBKWebhook {
 
     // --- constructs a bbk webhook object
 
-    constructor() {
+    constructor(label) {
         this.app = express();
         this.router = express.Router();
 
@@ -93,6 +93,15 @@ module.exports = class BBKWebhook {
             } else {
                 BBKWebhook._http_server_error(res);
             }
+        });
+
+        this.label = label || {};
+
+        // --- handler / route
+
+        this.router.get('/', (req, res) => {
+            this.label.now = new Date().toISOString();
+            res.json(this.label);
         });
 
         // --- handler /entity route

--- a/connectors/nodejs/rdbms/index.js
+++ b/connectors/nodejs/rdbms/index.js
@@ -221,6 +221,6 @@ new MyCatalog().upsert();
   all your data into the bbk catalog instead.
 */
 
-new MyWebhook().listen(WEBHOOK_PORT, () => {
+new MyWebhook({ name: "BBK RDBMS Example Connector", entity: ENTITY_TYPE, connectorId: CONNECTOR_ID }).listen(WEBHOOK_PORT, () => {
     console.log(`Webhook is listening on port ${ WEBHOOK_PORT }`);
 });

--- a/development/scripts/docker-compose-nodejs-file.yml
+++ b/development/scripts/docker-compose-nodejs-file.yml
@@ -29,6 +29,7 @@ services:
     container_name: bbk-con-country
     environment:
       - NODE_ENV=production
+      - ENTITY_TYPE=country
       - CATALOG_HOST=http://bbk-contributor:8002/v1/
       - CONNECTOR_ID=${ID_country}
       - AUTHORIZE_KEY=${TOKEN_country}
@@ -47,6 +48,7 @@ services:
     container_name: bbk-con-heritagenatural
     environment:
       - NODE_ENV=production
+      - ENTITY_TYPE=heritagesites
       - CATALOG_HOST=http://bbk-contributor:8002/v1/
       - CONNECTOR_ID=${ID_heritagenatural}
       - AUTHORIZE_KEY=${TOKEN_heritagenatural}
@@ -65,6 +67,7 @@ services:
     container_name: bbk-con-heritagecultural
     environment:
       - NODE_ENV=production
+      - ENTITY_TYPE=heritagesites
       - CATALOG_HOST=http://bbk-contributor:8002/v1/
       - CONNECTOR_ID=${ID_heritagecultural}
       - AUTHORIZE_KEY=${TOKEN_heritagecultural}


### PR DESCRIPTION
Added a '/' endpoint to webhook implementation in example connectors; can be used for liveness checks etc.

To test, deploy connectors per /development/scripts/README.md

deployed connectors should respond to GET on / with basic connector info e.g.

```
{
	"name": "BBK RDBMS Example Connector",
	"entity": "heritagesites",
	"connectorId": "03703f2dbcc5677c51f4204cf85822d6296ee507",
	"now": "2022-05-26T14:05:01.830Z"
}
```