### PR TITLE
app query params to support deep links, and other minor changes

### DIFF
--- a/apps/explorer/index.html
+++ b/apps/explorer/index.html
@@ -119,8 +119,8 @@
       <div class="col-md-9 my-2">
         <input type="text"  id="idApiUrl"  class="form-control" readonly/>
       </div>
-      <div class="col-md-1 my-2" id="idCopyCurl">
-        
+      <div class="col-md-1 my-2">
+        <button id="idCopyCurlButton" type="button" data-link="" class="btn btn-primary" hidden>Copy Curl</button>
       </div>
     </div>
     <div class="row">
@@ -153,11 +153,11 @@
     <nav aria-label="Page navigation example">
       <ul class="pagination">
         <li class="page-item">
-          <button hidden class="page-link previous" id="previous-bottom">Previous</button>
+          <button hidden class="page-link previous" id="previous-bottom">Previous Page</button>
           
         </li>
         <li class="page-item">
-          <button hidden class="page-link next" id="next-bottom">Next</button>
+          <button hidden class="page-link next" id="next-bottom">Next Page</button>
         </li>
       </ul>
     </nav>

--- a/apps/explorer/index.js
+++ b/apps/explorer/index.js
@@ -92,19 +92,13 @@ const bbkUrl = (url) => {
     return link;
 };
 
-/* Render Copy to Curl button
+/* Update Copy to Curl button
  */
 
-const RenderCopyCurlButton = (url) => {
-    const curlButton = document.createElement("button");
-    curlButton.innerText = "copy Curl";
-    curlButton.type = "button";
-    curlButton.setAttribute("data-link", url);
-    curlButton.classList.add("btn", "btn-primary");
-    curlButton.addEventListener("click", function(e) {
-        copyCurlToClipBoard(e.target.getAttribute("data-link"));
-    });
-    return curlButton;
+const updateCopyCurlButton = (url) => {
+    const copyCurl = document.getElementById("idCopyCurlButton");
+    copyCurl.removeAttribute('hidden');
+    copyCurl.setAttribute("data-link", url);
 };
 
 /* Render bit-broker Timeseries info in entity view
@@ -319,10 +313,8 @@ function consumerAPIFetch(url) {
         spinner.setAttribute("hidden", "");
         const apiUrl = document.getElementById("idApiUrl");
         apiUrl.value = previousUrl;
-        const copyCurl = document.getElementById("idCopyCurl");
-        copyCurl.replaceChildren();
-        copyCurl.appendChild(RenderCopyCurlButton(previousUrl));
-
+        updateCopyCurlButton(previousUrl);
+        
         paginationVisibility(((urlType == BBK_CATALOG) || (urlType == BBK_ENTITY_TYPE)) ? true : false);
 
         if (Array.isArray(data)) {
@@ -665,4 +657,9 @@ window.addEventListener("DOMContentLoaded", (event) => {
 
     const token = document.getElementById("token");
     token.addEventListener("change", (event) => (myToken = event.target.value));
+
+    const copyCurl = document.getElementById("idCopyCurlButton");
+    copyCurl.addEventListener("click", function(e) {
+        copyCurlToClipBoard(e.target.getAttribute("data-link"));
+    });
 });


### PR DESCRIPTION
Explorer app now supports a set of query params to reflect an intended BBK Consumer API call / query, which can be used to support a deep link. These are:

*   Policy      policy=policy-slug
*   Catalog:    q= (exactly per the catalog api query syntax)
*   Entity:     entity=entity_type
*              entity=entity_type&id=entity_id
*   Timeseries: entity=entity_type&id=entity_id&timeseries=timeseries_id

It also simplifies other aspects of the app, for example where we present a link to another BBK api url, we can generate and use a deep link, rather than needing to override the click event to override handling of these links by the app.

It also means that the browser address history reflects a BBK API call history so we don't need to maintain an internal history.

Other changes include displaying the actual BBK query made at the top of the results pane to improve transparency about what is going on 'under the hood', and only showing paging controls for API calls that return arrays of objects.