### PR TITLE
Added devShimMode to example webapps (defaults false)

### DIFF
--- a/apps/explorer/config/example-config.json
+++ b/apps/explorer/config/example-config.json
@@ -19,5 +19,6 @@
             "token": "<TOKEN GOES HERE>"
         }
     ],
-    "baseUrl": "http://bbk-consumer:8003/v1"
+    "baseUrl": "http://bbk-consumer:8003/v1",
+    "devShimMode": false
 }

--- a/apps/explorer/index.js
+++ b/apps/explorer/index.js
@@ -69,6 +69,7 @@ let myPolicy = null;
 
 let baseURL = "";
 let previousUrl = "";
+let devShimMode = false;
 
 /* Convert http(s) urls to clickable links inline
  */
@@ -349,13 +350,16 @@ function consumerAPIFetch(url) {
     paginationVisibility(false);
     timeSeriesButtonsVisibility(false);
 
-    const requestOptions = {
+    let requestOptions = {
         method: "GET",
         headers: {
-            "x-bbk-auth-token": myToken,
-            "x-bbk-audience": myPolicy,
-        },
+            "x-bbk-auth-token": myToken
+        }
     };
+
+    if (devShimMode) {
+        requestOptions.headers["x-bbk-audience"] = myPolicy;
+    }
 
     let urlType = bbkUrlType(url);
 
@@ -725,6 +729,7 @@ window.addEventListener("DOMContentLoaded", (event) => {
     .then((res) => (res.ok ? res.json() : Promise.reject(res)))
     .then((config) => {
         baseURL = config.baseUrl;
+        devShimMode = config.devShimMode;
         document.getElementById("baseurl").value = baseURL;
 
         policyDropdownValue(config.policies);

--- a/apps/map/config.example.json
+++ b/apps/map/config.example.json
@@ -4,6 +4,7 @@
     "coordinator": "http://bbk-coordinator:8001"
   },
   "useStaticPolicies": true,
+  "devShimMode": false,
   "policies": [
     {
       "id": "access-all-areas",

--- a/apps/map/script.js
+++ b/apps/map/script.js
@@ -18,6 +18,16 @@ function initMap() {
   document.querySelector('.no-data-info').style.visibility = 'hidden';
 }
 
+function headers(policy) {
+  let headers = {
+    'x-bbk-auth-token':  policy.token
+  };
+  if (window.config.devShimMode) {
+    headers['x-bbk-audience'] = policy.id
+  }
+  return headers;
+}
+
 function mergeQueryParam(name, value) {
   const url = new URL(window.location);
   if (!value) {
@@ -55,18 +65,12 @@ async function getData() {
   }
 
   const response = await fetch(`${window.config.services.consumer}/v1/entity/${selectedEntity.id}`, {
-    headers: {
-      'x-bbk-audience': selectedPolicy.id,
-      'x-bbk-auth-token': selectedPolicy.token
-    }
+    headers: headers(selectedPolicy)
   });
   const data = await response.json();
 
   const dataDetails = await Promise.all(data.map(d => fetch(d.url, {
-    headers: {
-      'x-bbk-audience': selectedPolicy.id,
-      'x-bbk-auth-token':  selectedPolicy.token
-    },
+    headers: headers(selectedPolicy)
   }).then(res => res.json())));
   window.data = dataDetails;
 
@@ -118,10 +122,7 @@ function initEvents() {
 
 async function getEntities() {
   const entities = await fetch(`${window.config.services.consumer}/v1/entity`, {
-    headers: {
-      'x-bbk-auth-token': window.selectedPolicy.token,
-      'x-bbk-audience': window.selectedPolicy.id,
-    },
+    headers: headers(window.selectedPolicy)
   }).then(res => res.json());
   window.entities = entities;
 }

--- a/build/app-explorer/docker-entrypoint.sh
+++ b/build/app-explorer/docker-entrypoint.sh
@@ -10,6 +10,12 @@ else
   jq --arg baseUrl "$BASE_URL" '.baseUrl = $baseUrl' "$configfile" > "$tmp" && mv "$tmp" "$configfile"
 fi
 
+if [[ -z "${DEV_SHIM_MODE}" ]]; then
+  :
+else
+  jq --argjson devShimMode $DEV_SHIM_MODE '.devShimMode = $devShimMode' "$configfile" > "$tmp" && mv "$tmp" "$configfile"
+fi
+
 PREFIX_LIST=("POLICY_ TOKEN_ NAME_ DESC_")
 
 for PREFIX in ${PREFIX_LIST[*]}; do

--- a/build/app-map/docker-entrypoint.sh
+++ b/build/app-map/docker-entrypoint.sh
@@ -10,6 +10,12 @@ else
   jq --arg baseUrl "$BASE_URL" '.services.consumer = $baseUrl' "$configfile" > "$tmp" && mv "$tmp" "$configfile"
 fi
 
+if [[ -z "${DEV_SHIM_MODE}" ]]; then
+  :
+else
+  jq --argjson devShimMode $DEV_SHIM_MODE '.devShimMode = $devShimMode' "$configfile" > "$tmp" && mv "$tmp" "$configfile"
+fi
+
 PREFIX_LIST=("POLICY_ TOKEN_ NAME_ DESC_")
 
 for PREFIX in ${PREFIX_LIST[*]}; do

--- a/development/scripts/README.md
+++ b/development/scripts/README.md
@@ -8,6 +8,18 @@ All the deployments have a single connector hosting 'country' data, and two 'her
 
 ## Deployment
 
+NB a fundamental difference between the docker-compose & helm environments is that the docker-compose environment does not include the emissary API gateway, and the auth & rate services are stubbed. This means there is a key difference in the way the consumer API calls should be made:
+
+- In a Helm deployment, the consumer API calls only require the 'x-bbk-auth-token' header
+- In a docker-compose environment, the consumer API calls only both the 'x-bbk-auth-token' & 'x-bbk-audience' headers
+
+Both the map & explorer example apps have a config property devShimMode (which can be set though the docker env var DEV_SHIM_MODE)
+
+- when false, the apps only send the 'x-bbk-auth-token' header
+- when true, the apps send both the 'x-bbk-auth-token' & 'x-bbk-audience' headers
+
+devShimMode defaults to false, which is appropriate for Helm / production environments, but will be enabled when deploying using docker-compose.
+
 ### docker-compose
 
 First, clone the https://github.com/bit-broker/bit-broker repo.

--- a/development/scripts/docker-compose-nodejs-file.yml
+++ b/development/scripts/docker-compose-nodejs-file.yml
@@ -94,6 +94,7 @@ services:
     container_name: bbk-app-explorer
     environment:
       BASE_URL: http://bbk-consumer:8003/v1
+      DEV_SHIM_MODE: true
       TOKEN_0: ${BBK_POLICY_TOKEN_access_all_areas}
       TOKEN_1: ${BBK_POLICY_TOKEN_geo_british_isles}
       TOKEN_2: ${BBK_POLICY_TOKEN_heritage_natural}
@@ -119,6 +120,8 @@ services:
       dockerfile: ./build/app-map/Dockerfile
     container_name: bbk-app-map
     environment:
+      BASE_URL: http://bbk-consumer:8003
+      DEV_SHIM_MODE: true
       TOKEN_0: ${BBK_POLICY_TOKEN_access_all_areas}
       TOKEN_1: ${BBK_POLICY_TOKEN_geo_british_isles}
       TOKEN_2: ${BBK_POLICY_TOKEN_heritage_natural}

--- a/development/scripts/docker-compose-nodejs-rdbms.yml
+++ b/development/scripts/docker-compose-nodejs-rdbms.yml
@@ -108,6 +108,7 @@ services:
     container_name: bbk-app-explorer
     environment:
       BASE_URL: http://bbk-consumer:8003/v1
+      DEV_SHIM_MODE: true
       TOKEN_0: ${BBK_POLICY_TOKEN_access_all_areas}
       TOKEN_1: ${BBK_POLICY_TOKEN_geo_british_isles}
       TOKEN_2: ${BBK_POLICY_TOKEN_heritage_natural}
@@ -134,6 +135,7 @@ services:
     container_name: bbk-app-map
     environment:
       BASE_URL: http://bbk-consumer:8003
+      DEV_SHIM_MODE: true
       TOKEN_0: ${BBK_POLICY_TOKEN_access_all_areas}
       TOKEN_1: ${BBK_POLICY_TOKEN_geo_british_isles}
       TOKEN_2: ${BBK_POLICY_TOKEN_heritage_natural}


### PR DESCRIPTION
Per README change:

NB a fundamental difference between the docker-compose & helm environments is that the docker-compose environment does not include the emissary API gateway, and the auth & rate services are stubbed. This means there is a key difference in the way the consumer API calls should be made:

- In a Helm deployment, the consumer API calls only require the 'x-bbk-auth-token' header
- In a docker-compose environment, the consumer API calls only both the 'x-bbk-auth-token' & 'x-bbk-audience' headers

Both the map & explorer example apps have a config property devShimMode (which can be set though the docker env var DEV_SHIM_MODE)

- when false, the apps only send the 'x-bbk-auth-token' header
- when true, the apps send both the 'x-bbk-auth-token' & 'x-bbk-audience' headers

devShimMode defaults to false, which is appropriate for Helm / production environments, but will be enabled when deploying using docker-compose.