### PR TITLE
fix: Added custom 404 error page to app-demo nginx conf ...

### DIFF
--- a/apps/demo/404.html
+++ b/apps/demo/404.html
@@ -1,0 +1,12 @@
+<html>
+<head><title>404 Not Found</title></head>
+<body>
+<center><h1>404 Not Found</h1></center>
+</body>
+</html>
+<!-- a padding to disable MSIE and Chrome friendly error page -->
+<!-- a padding to disable MSIE and Chrome friendly error page -->
+<!-- a padding to disable MSIE and Chrome friendly error page -->
+<!-- a padding to disable MSIE and Chrome friendly error page -->
+<!-- a padding to disable MSIE and Chrome friendly error page -->
+<!-- a padding to disable MSIE and Chrome friendly error page -->

--- a/build/app-demo/Dockerfile
+++ b/build/app-demo/Dockerfile
@@ -14,11 +14,13 @@ RUN rm -rf ./*
 
 # Copy assets over so Nginx can properly serve 
 COPY apps/demo/index.html .
+COPY apps/demo/404.html .
 
 RUN chown -R nginx:nginx /usr/share/nginx/html
 
 # implement changes required to run NGINX as an unprivileged user
 RUN sed -i 's,listen       80;,listen       8080;,' /etc/nginx/conf.d/default.conf \
+    && sed -i 's,#error_page  404,error_page  404,' /etc/nginx/conf.d/default.conf \
     && sed -i '/user  nginx;/d' /etc/nginx/nginx.conf \
     && sed -i 's,/var/run/nginx.pid,/tmp/nginx.pid,' /etc/nginx/nginx.conf \
     && sed -i "/^http {/a \    proxy_temp_path /tmp/proxy_temp;\n    client_body_temp_path /tmp/client_temp;\n    fastcgi_temp_path /tmp/fastcgi_temp;\n    uwsgi_temp_path /tmp/uwsgi_temp;\n    scgi_temp_path /tmp/scgi_temp;\n" /etc/nginx/nginx.conf \

--- a/build/app-demo/Dockerfile
+++ b/build/app-demo/Dockerfile
@@ -23,7 +23,7 @@ RUN sed -i 's,listen       80;,listen       8080;,' /etc/nginx/conf.d/default.co
     && sed -i 's,#error_page  404,error_page  404,' /etc/nginx/conf.d/default.conf \
     && sed -i '/user  nginx;/d' /etc/nginx/nginx.conf \
     && sed -i 's,/var/run/nginx.pid,/tmp/nginx.pid,' /etc/nginx/nginx.conf \
-    && sed -i "/^http {/a \    proxy_temp_path /tmp/proxy_temp;\n    client_body_temp_path /tmp/client_temp;\n    fastcgi_temp_path /tmp/fastcgi_temp;\n    uwsgi_temp_path /tmp/uwsgi_temp;\n    scgi_temp_path /tmp/scgi_temp;\n" /etc/nginx/nginx.conf \
+    && sed -i "/^http {/a \    proxy_temp_path /tmp/proxy_temp;\n    client_body_temp_path /tmp/client_temp;\n    fastcgi_temp_path /tmp/fastcgi_temp;\n    uwsgi_temp_path /tmp/uwsgi_temp;\n    scgi_temp_path /tmp/scgi_temp;\n    server_tokens off;\n" /etc/nginx/nginx.conf \
     # nginx user must own the cache and etc directory to write cache and tweak the nginx config
     && chown -R $UID:0 /var/cache/nginx \
     && chmod -R g+w /var/cache/nginx \


### PR DESCRIPTION
fix: Added custom 404 error page to app-demo nginx conf with server details removed.
The app-demo service provides a trivial web-page that redirects to https://www.bit-broker.io/docs/getting-started/demo/
However, because the k8s deployment maps this to / (e.g. demo.bit-broker.io), any access to /some/invalid/path gets handled by this service, for which nginx will 404. This was configured to use the default nginx error message which includes basic server version info.
To address this, a custom 404 error page has been added & enabled which removes any server info.

NB nginx is still returning a server header, the version info has been disabled, but it's non-trivial (i.e. requires a 3rd party module) to strip the Server header completely e.g. per https://www.getpagespeed.com/server-setup/nginx/how-to-remove-the-server-header-in-nginx